### PR TITLE
Fix typo in README (dl_all_lm -> dl_all_lms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `Makefile` is used to train Sentence Piece and LM on Wikipedia data.
 * `make lang=de lm` trains a Sentence Piece and a LM on German Wikipedia
 * `make all_lm` trains the same model than in the paper
 * `make lang=de dl_lm` downloads the LM trained for the paper
-* `make dl_all_lm` downloads all of them
+* `make dl_all_lms` downloads all of them
 
 ## Pipeline overview
 


### PR DESCRIPTION
I found a typo in README file.

It seems that `make dl_all_lm` should be `make dl_all_lms` in `README.md` as it is defined in makefile.

I tested it is working well. 😃 