### PR TITLE
update wet url root

### DIFF
--- a/cc_net/process_wet_file.py
+++ b/cc_net/process_wet_file.py
@@ -20,7 +20,7 @@ from bs4 import BeautifulSoup  # type: ignore
 
 from cc_net import jsonql
 
-WET_URL_ROOT = "https://commoncrawl.s3.amazonaws.com"
+WET_URL_ROOT = "https://data.commoncrawl.org"
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The previous `WET_URL_ROOT` is not accessible now (403). CC updated it.